### PR TITLE
Correctly verify the SSL certificate presented has a CNAME matching the ...

### DIFF
--- a/src/libtwitter.c
+++ b/src/libtwitter.c
@@ -325,7 +325,7 @@ int twitter_fetch(twitter_t *twitter, const char *apiuri, GByteArray *buf)
 
     curl_easy_setopt(curl, CURLOPT_URL, apiuri);
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, TRUE);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, TRUE);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2);
     /* 2010-08-31 no need basic auth
       curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
       curl_easy_setopt(curl, CURLOPT_USERPWD, userpass);


### PR DESCRIPTION
...requested host

The cURL manual explains the correct usage of CURLOPT_SSL_VERIFYHOST as follows:

1 to check the existence of a common name in the SSL peer certificate. 2 to check the existence of a common name and also verify that it matches the hostname provided. In production environments the value of this option should be kept at 2 (default value).

See http://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf for a full analysis of the security vulnerability here.
